### PR TITLE
Fully backwards compatible fix for FUSION_ONCREWZERO

### DIFF
--- a/data/events_special_main.xml.append
+++ b/data/events_special_main.xml.append
@@ -6,9 +6,6 @@
 		<mod-append:triggeredEvent name="FUSION_ONDAMAGE" event="FUSION_ONDAMAGE">
 			<playerDamage amount="1" countRepairs="false"/>
 		</mod-append:triggeredEvent>
-		<mod-append:triggeredEvent name="FUSION_ONCREWZERO" event="FUSION_ONCREWZERO">
-			<enemyCrew amount="0" includeClonebay="true"/><!--Triggers when enemy has no crew, can be used for CK/autoship-specific things that can be checked in lua, may have to implement queueEvent for when the ship CHANGES to an auto so it checks after that, depending on order of events-->
-		</mod-append:triggeredEvent>
 	</mod:findName>
 
 	<event name="ADDON_FUSION_INFO">

--- a/data/events_special_mechanical.xml.append
+++ b/data/events_special_mechanical.xml.append
@@ -4,7 +4,6 @@
      <jumps amount="1" type="0"/>
    </triggeredEvent>
    <!--<queueEvent>EVENTNAME</queueEvent> append more of those lines for each independent effect-->
-   <queueEvent>FUSION_ONCREWZERO_SETUP</queueEvent>
  </event>
  <event name="FUSION_ONDAMAGE">
    <triggeredEvent name="FUSION_ONDAMAGE" event="FUSION_ONDAMAGE">
@@ -12,12 +11,7 @@
    </triggeredEvent>
    <!--<queueEvent>EVENTNAME</queueEvent> append more of those lines for each independent effect-->
  </event>
- <event name="FUSION_ONCREWZERO_SETUP">
-    <triggeredEvent name="FUSION_ONCREWZERO" event="FUSION_ONCREWZERO">
-      <enemyCrew amount="0" includeClonebay="true" thisFight="true"/><!--Triggers when enemy has no crew, can be used for CK/autoship-specific things that can be checked in lua, may have to implement queueEvent for when the ship CHANGES to an auto so it checks after that, depending on order of events-->
-    </triggeredEvent>
- </event>
- <event name="FUSION_ONCREWZERO"/>
+ <event name="FUSION_ONCREWZERO"/> <!--Triggers when enemy has no crew, can be used for CK-specific things that can be checked in lua-->
  <event name="FUSION_RESET" unused="true"><!-- use this if you installed mid-run to activate the effects-->
    <text id="event_FUSION_RESET_text"/>
    <clearTriggeredEvent name="FUSION_ONJUMP"/>

--- a/data/events_special_mechanical.xml.append
+++ b/data/events_special_mechanical.xml.append
@@ -11,7 +11,7 @@
    </triggeredEvent>
    <!--<queueEvent>EVENTNAME</queueEvent> append more of those lines for each independent effect-->
  </event>
- <event name="FUSION_ONCREWZERO"/> <!--Triggers when enemy has no crew, can be used for CK-specific things that can be checked in lua-->
+ <event name="FUSION_ONCREWZERO"/> <!--Triggers when enemy has no crew, can be used for CK/autoship-specific things that can be checked in lua, may have to implement queueEvent for when the ship CHANGES to an auto so it checks after that, depending on order of events-->
  <event name="FUSION_RESET" unused="true"><!-- use this if you installed mid-run to activate the effects-->
    <text id="event_FUSION_RESET_text"/>
    <clearTriggeredEvent name="FUSION_ONJUMP"/>

--- a/data/fusion_scripts/eventCallbacks.lua
+++ b/data/fusion_scripts/eventCallbacks.lua
@@ -37,7 +37,7 @@ end)
 
 -- Use script.on_game_event with "FUSION_ONCREWZERO" to use this
 script.on_internal_event(Defines.InternalEvents.SHIP_LOOP, function(ship)
-	if ship.iShipId == 0 or ship.bAutomated or ranOnCrewZero then return end
+	if ship.iShipId == 0 or ranOnCrewZero then return end
 	
 	local shipCrew = userdata_table(ship, "mods.fusion.eventCallbacks").shipCrew
 	-- new crew could potentially be added mid-fight

--- a/data/fusion_scripts/eventCallbacks.lua
+++ b/data/fusion_scripts/eventCallbacks.lua
@@ -1,0 +1,67 @@
+local userdata_table = mods.multiverse.userdata_table
+local vter = mods.fusion.vter
+
+local function addNewCrew(shipCrew, ship)
+	local function validCrewmember(crewmember)
+		return not shipCrew["crew"][crewmember] and crewmember.iShipId == ship.iShipId and crewmember:IsCrew()
+	end
+	
+	for crewmember in vter(ship.vCrewList) do
+		if validCrewmember(crewmember) then
+			shipCrew["crew"][crewmember] = true
+		elseif not shipCrew["repairDrones"][crewmember] and crewmember:CanRepair() then
+			shipCrew["repairDrones"][crewmember] = true
+		end
+	end
+	
+	for crewmember in vter(Hyperspace.ships(1 - ship.iShipId).vCrewList) do
+		if validCrewmember(crewmember) then
+			shipCrew["crew"][crewmember] = true
+		end
+	end
+end
+
+local ranOnCrewZero = false
+script.on_internal_event(Defines.InternalEvents.GENERATOR_CREATE_SHIP_POST, function(_, _2, _3, _4, ship)
+	userdata_table(ship, "mods.fusion.eventCallbacks").shipCrew = {["crew"] = {}, ["repairDrones"] = {}}
+	local shipCrew = userdata_table(ship, "mods.fusion.eventCallbacks").shipCrew
+	
+	addNewCrew(shipCrew, ship)
+	
+	if ship:HasSystem(13) then
+		shipCrew["clonebay"] = ship:GetSystem(13)
+	end
+	
+	ranOnCrewZero = false
+end)
+
+-- Use script.on_game_event with "FUSION_ONCREWZERO" to use this
+script.on_internal_event(Defines.InternalEvents.SHIP_LOOP, function(ship)
+	if ship.iShipId == 0 or ship.bAutomated or ranOnCrewZero then return end
+	
+	local shipCrew = userdata_table(ship, "mods.fusion.eventCallbacks").shipCrew
+	-- new crew could potentially be added mid-fight
+	addNewCrew(shipCrew, ship)
+	
+	if shipCrew["clonebay"] and shipCrew["clonebay"]:Functioning() then return end
+	
+	crewCount = 0
+	for crew, _ in pairs(shipCrew["crew"]) do
+		if not (crew:IsDead() or crew.health.first <= 0 or crew.extend.noSlot) then
+			crewCount = crewCount + 1
+		end
+	end
+	
+	if shipCrew["clonebay"] then
+		for drone, _ in pairs(shipCrew["repairDrones"]) do
+			if not (drone:IsDead() or drone.health.first <= 0 or not drone:Functional()) then
+				crewCount = crewCount + 1
+			end
+		end
+	end
+	
+	if crewCount == 0 then
+		ranOnCrewZero = true
+		Hyperspace.CustomEventsParser.GetInstance():LoadEvent(Hyperspace.App.world, "FUSION_ONCREWZERO", false, -1)
+	end
+end, 1001)

--- a/data/hyperspace.xml.append
+++ b/data/hyperspace.xml.append
@@ -85,6 +85,7 @@
 		<mod-append:script>data/fusion_scripts/dependancy.lua</mod-append:script><!--The script folders are named differently because of issues when two script files share the same path.-->
 		<mod-append:script>data/fusion_scripts/utility.lua</mod-append:script>
 		<mod-append:script>data/fusion_scripts/callbacks.lua</mod-append:script>
+		<mod-append:script>data/fusion_scripts/eventCallbacks.lua</mod-append:script>
 		<mod-append:script>data/fusion_scripts/antiAugments.lua</mod-append:script>
 		<mod-append:script>data/fusion_scripts/systems.lua</mod-append:script>
 		<mod-append:script>data/fusion_scripts/weapon_fire.lua</mod-append:script>


### PR DESCRIPTION
This is a fix for FUSION_ON_CREW_ZERO that is fully backwards compatible. It will run when a crew kill happens and when a crewless auto-ship spawns.